### PR TITLE
Migrate to `mxpy`, use `sc-meta` for builds

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Generate the contract report
         run: |
-          sc-meta all build --wasm-symbols --wasm-suffix dbg --no-wasm-opt --no-imports --target-dir $(pwd)/target --path .
+          sc-meta all build --wasm-symbols --wasm-suffix dbg --no-wasm-opt --twiggy-paths --no-imports --target-dir $(pwd)/target --path .
           mxpy contract report --skip-build --skip-twiggy --output-format json --output-file report.json
 
       - name: Upload the report json

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -48,7 +48,7 @@ jobs:
           toolchain: ${{ inputs.rust-toolchain }}
           target: wasm32-unknown-unknown
       - name: Setup the PATH variable
-        run: echo "PATH=$HOME/.local/bin:$HOME/multiversx-sdk/vmtools:$PATH" >> $GITHUB_ENV
+        run: echo "PATH=$HOME/.local/bin:$HOME/multiversx-sdk/vmtools:$HOME/multiversx-sdk/nodejs/latest/bin:$PATH" >> $GITHUB_ENV
 
       - name: Install prerequisites
         run: |

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -70,7 +70,7 @@ jobs:
           sudo apt install -y libtinfo5
 
       - name: Build the wasm contracts
-        run: sc-meta all build --target-dir $(pwd)/target --path .
+        run: sc-meta all build --no-imports --target-dir $(pwd)/target --path .
 
       - name: Run the wasm tests
         run: cargo test --features multiversx-sc-scenario/run-go-tests

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -47,6 +47,7 @@ jobs:
           default: true
           toolchain: ${{ inputs.rust-toolchain }}
           target: wasm32-unknown-unknown
+
       - name: Setup the PATH variable
         run: echo "PATH=$HOME/.local/bin:$HOME/multiversx-sdk/vmtools:$HOME/multiversx-sdk/nodejs/latest/bin:$PATH" >> $GITHUB_ENV
 

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -13,19 +13,9 @@ on:
         default: 'latest'
         required: false
         type: string
-      pip-erdpy-args:
-        description: 'pip erdpy install arguments'
-        default: 'erdpy'
-        required: false
-        type: string
-      extra-build-args:
-        description: 'extra build arguments'
-        default: ''
-        required: false
-        type: string
-      wasm-tests-args:
-        description: 'wasm tests arguments'
-        default: '--features elrond-wasm-debug/mandos-go-tests'
+      pip-mxpy-args:
+        description: 'pip mxpy install arguments'
+        default: 'multiversx-sdk-cli'
         required: false
         type: string
       clippy-args:
@@ -61,14 +51,16 @@ jobs:
 
       - name: Install prerequisites
         run: |
-          pip3 install ${{ inputs.pip-erdpy-args }}
+          pip3 install ${{ inputs.pip-mxpy-args }}
           mkdir $HOME/elrondsdk
-          erdpy deps install vmtools --tag ${{ inputs.vmtools-version }}
+          mxpy deps install vmtools --tag ${{ inputs.vmtools-version }}
 
-          erdpy deps install nodejs
-          erdpy deps install wasm-opt
+          mxpy deps install nodejs
+          mxpy deps install wasm-opt
 
           cargo install twiggy
+
+          cargo install multiversx-sc-meta
 
       - name: Install libtinfo5
         if: inputs.install-libtinfo5
@@ -77,13 +69,13 @@ jobs:
           sudo apt install -y libtinfo5
 
       - name: Build the wasm contracts
-        run: erdpy contract build -r ${{ inputs.extra-build-args }}
+        run: sc-meta all build --target-dir $(pwd)/target --path .
 
       - name: Run the wasm tests
-        run: cargo test ${{ inputs.wasm-tests-args }}
+        run: cargo test --features multiversx-sc-scenario/run-go-tests
 
       - name: Generate the contract report
-        run: erdpy contract report --skip-build --output-format json --output-file report.json
+        run: mxpy contract report --skip-build --output-format json --output-file report.json
 
       - name: Upload the report json
         uses: actions/upload-artifact@v3
@@ -108,9 +100,9 @@ jobs:
           if [ ! -f base-report/report.json ]
           then
               echo ":warning: Warning: Could not download the report for the base branch. Displaying only the report for the current branch. :warning:" >> report.md
-              erdpy contract report --compare report.json --output-format github-markdown --output-file report-table.md
+              mxpy contract report --compare report.json --output-format github-markdown --output-file report-table.md
           else
-              erdpy contract report --compare base-report/report.json report.json --output-format github-markdown --output-file report-table.md
+              mxpy contract report --compare base-report/report.json report.json --output-format github-markdown --output-file report-table.md
           fi
           cat report-table.md >> report.md
 

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Generate the contract report
         run: |
-          sc-meta all build --wasm-symbols --wasm-suffix dbg --no-wasm-opt --twiggy-paths --no-imports --target-dir $(pwd)/target --path .
+          sc-meta all build-dbg --twiggy-paths --target-dir $(pwd)/target --path .
           mxpy contract report --skip-build --skip-twiggy --output-format json --output-file report.json
 
       - name: Upload the report json

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -76,7 +76,9 @@ jobs:
         run: cargo test --features multiversx-sc-scenario/run-go-tests
 
       - name: Generate the contract report
-        run: mxpy contract report --skip-build --output-format json --output-file report.json
+        run: |
+          sc-meta all build --wasm-symbols --wasm-suffix dbg --no-wasm-opt --no-imports --target-dir $(pwd)/target --path .
+          mxpy contract report --skip-build --skip-twiggy --output-format json --output-file report.json
 
       - name: Upload the report json
         uses: actions/upload-artifact@v3

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -47,12 +47,12 @@ jobs:
           toolchain: "${{ inputs.rust-toolchain }}"
 
       - name: Setup the PATH variable
-        run: echo "PATH=$HOME/.local/bin:$HOME/elrondsdk/vmtools:$PATH" >> $GITHUB_ENV
+        run: echo "PATH=$HOME/.local/bin:$HOME/multiversx-sdk/vmtools:$PATH" >> $GITHUB_ENV
 
       - name: Install prerequisites
         run: |
           pip3 install ${{ inputs.pip-mxpy-args }}
-          mkdir $HOME/elrondsdk
+          mkdir $HOME/multiversx-sdk
           mxpy deps install vmtools --tag ${{ inputs.vmtools-version }}
 
           mxpy deps install nodejs

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -43,9 +43,10 @@ jobs:
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
+          profile: minimal
           default: true
-          toolchain: "${{ inputs.rust-toolchain }}"
-
+          toolchain: ${{ inputs.rust-toolchain }}
+          target: wasm32-unknown-unknown
       - name: Setup the PATH variable
         run: echo "PATH=$HOME/.local/bin:$HOME/multiversx-sdk/vmtools:$PATH" >> $GITHUB_ENV
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Github Action for smart contracts which:
 - builds the wasm files
-- runs mandos-rs and mandos-go tests
+- runs both the rust and go testing scenarios
 - does a clippy check
 - provides a report containing details about the smart contracts
 
@@ -10,10 +10,7 @@ A Github Action for smart contracts which:
 
 ### Standard build
 
-See [contracts.yml](.github/workflows/contracts.yml)
-This uses fixed versions of rust and vmtools.
-Ignores `eei` checks which allows the contracts to use features which are not live on the elrond mainnet yet.
-
+Create a new file under `.github/workflows/actions.yml` with the following contents:
 ```yml
 name: CI
 
@@ -30,14 +27,16 @@ permissions:
 jobs:
   contracts:
     name: Contracts
-    uses: ElrondNetwork/elrond-actions/.github/workflows/contracts.yml@v1
+    uses: multiversx/mx-sc-actions/.github/workflows/contracts.yml@v2
     with:
-      rust-toolchain: nightly-2022-01-17
-      vmtools-version: v1.4.43
-      extra-build-args: --ignore-eei-checks
+      rust-toolchain: nightly-2022-12-08
+      vmtools-version: v1.4.60
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+This uses fixed versions of rust and vmtools.
+See [contracts.yml](.github/workflows/contracts.yml) for more details on which other arguments are supported.
 
 ### Main branch notes
 
@@ -65,11 +64,11 @@ permissions:
 
 ## Additional options
 
-### Using a custom erdpy version
+### Using a custom mxpy version
 
-The erdpy version can be specified by providing:
+The mxpy version can be specified by providing:
 ```yml
-pip-erdpy-args: erdpy==1.2.3
+pip-mxpy-args: multiversx-sdk-cli==1.2.3
 ```
 
 ### Installing libtinfo5


### PR DESCRIPTION
Updates:
- migrate from `erdpy` to `mxpy` (python package `multiversx-sdk-cli`)
- build the contracts using `sc-meta` instead of `erdpy contract build`
- build the contracts with the debug information using `sc-meta` (added `--skip-twiggy` to `erdpy contract report`)
- added the `wasm32-unknown-unknown` target (it was previously implicitly installed by `erdpy contract build`)
- added `profile: minimal` to the rust installation
- updated the documentation

Breaking changes:
- since the script now uses `mxpy`, the tool provided for running go test scenarios is `run-scenarios`, backwards incompatible with `mx-sdk-rs` versions which call `mandos-test`
- renamed the `pip-erdpy-args` argument to `pip-mxpy-args`
- removed `extra-build-args` since it's no longer used (it was previously used to specify `--ignore-eei-checks`)
- removed `wasm-tests-args` since the argument for the go scenario tests is now stable (`--features elrond-wasm-debug/mandos-go-tests`)
