### PR TITLE
Do not fail on warnings

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -180,5 +180,3 @@ jobs:
         with:
           github_token: ${{ secrets.token }}
           clippy_flags: ${{ inputs.clippy-args }}
-          level: warning
-          filter_mode: nofilter

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -69,12 +69,19 @@ jobs:
           sudo apt install -y libtinfo5
 
       - name: Build the wasm contracts
+        env:
+          RUSTFLAGS: ""
         run: sc-meta all build --no-imports --target-dir $(pwd)/target --path .
 
       - name: Run the wasm tests
-        run: cargo test --features multiversx-sc-scenario/run-go-tests
+        env:
+          RUSTFLAGS: ""
+        run:
+          cargo test --features multiversx-sc-scenario/run-go-tests
 
       - name: Generate the contract report
+        env:
+          RUSTFLAGS: ""
         run: |
           sc-meta all build-dbg --twiggy-paths --target-dir $(pwd)/target --path .
           mxpy contract report --skip-build --skip-twiggy --output-format json --output-file report.json
@@ -153,7 +160,10 @@ jobs:
           toolchain: ${{ inputs.rust-toolchain }}
 
       - name: Run the rust tests
-        run: cargo test
+        env:
+          RUSTFLAGS: ""
+        run:
+          cargo test
 
   clippy_check:
     name: Clippy linter check
@@ -165,6 +175,8 @@ jobs:
           toolchain: ${{ inputs.rust-toolchain }}
           components: clippy
       - uses: giraffate/clippy-action@v1
+        env:
+          RUSTFLAGS: ""
         with:
           github_token: ${{ secrets.token }}
           clippy_flags: ${{ inputs.clippy-args }}


### PR DESCRIPTION
The `actions-rust-lang/setup-rust-toolchain@v1` action sets the environment variable:
`RUSTFLAGS="-D warnings"`
which causes the build to fail when any warning is encountered.

This PR overrides the `RUSTFLAGS` environment variable with an empty string.

Also, removed the flags for clippy since they are no longer required.