### PR TITLE
Fix installation of wasm-opt, wabt

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -55,6 +55,7 @@ jobs:
           mkdir $HOME/multiversx-sdk
           python3 -m multiversx_sdk_cli.cli deps install vmtools --tag ${{ inputs.vmtools-version }}
           sudo apt install -y binaryen=105-1
+          sudo apt install -y wabt=1.0.27-1
 
           cargo install twiggy
 

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -47,14 +47,14 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: Setup the PATH variable
-        run: echo "PATH=$HOME/.local/bin:$HOME/multiversx-sdk/vmtools:$HOME/multiversx-sdk/wasm-opt/version_105:$PATH" >> $GITHUB_ENV
+        run: echo "PATH=$HOME/.local/bin:$HOME/multiversx-sdk/vmtools:$PATH" >> $GITHUB_ENV
 
       - name: Install prerequisites
         run: |
           pip3 install ${{ inputs.pip-mxpy-args }}
           mkdir $HOME/multiversx-sdk
           python3 -m multiversx_sdk_cli.cli deps install vmtools --tag ${{ inputs.vmtools-version }}
-          python3 -m multiversx_sdk_cli.cli deps install wasm-opt
+          sudo apt install -y binaryen=105-1
 
           cargo install twiggy
 


### PR DESCRIPTION
Install `wasm-opt`, `wabt` using `apt-get` (`binaryen` package) instead of using `mxpy`.