### PR TITLE
report retention time fix

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Upload the report json
         uses: actions/upload-artifact@v6
         with:
-          name: report-${{ github.run_id }}
-          retention-days: 1
+          name: report
+          retention-days: 90
           path: report.json
 
       - name: Download the base report


### PR DESCRIPTION
The retention time was too short to be useful. We were getting no more report comparisons. 90 days is a decent and appropriate amount.