### PR TITLE
Reproducible builds using sc-meta

### DIFF
--- a/.github/workflows/build-contracts.yml
+++ b/.github/workflows/build-contracts.yml
@@ -13,7 +13,7 @@ on:
         type: string
       rust-target:
         description: "Rust target to use"
-        default: "wasm32-unknown-unknown"
+        default: "wasm32v1-none"
         required: false
         type: string
 

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -31,7 +31,7 @@ on:
         type: string
       rust-target:
         description: "Rust target to use"
-        default: "wasm32-unknown-unknown"
+        default: "wasm32v1-none"
         required: false
         type: string
       sc-meta-version:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ on:
         type: string
       rust-target:
         description: "Rust target to use"
-        default: "wasm32-unknown-unknown"
+        default: "wasm32v1-none"
         required: false
         type: string
       coverage-args:

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -6,7 +6,7 @@ on:
       image_tag:
         type: string
         required: true
-        description: Image multiversx/sdk-rust-contract-builder
+        description: Image tag for multiversx/sdk-rust-contract-builder
       project_path:
         type: string
         default: '.'
@@ -22,120 +22,61 @@ on:
       attach_to_existing_release:
         type: boolean
         description: Whether to attach output to existing release
-      skip_preliminary_checks:
-        type: boolean
-        description: Skip preliminary checks. Never set this in production!
-      package_whole_project_src:
-        type: boolean
-        description: Include all project files in the packaged source (*.source.json) 
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Handle input
+      - name: Validate inputs
         run: |
-          python3 - << "EOF"
-          import logging
-          import os
-          import sys
-
-          logging.basicConfig(level=logging.INFO)
-
-          image_tag = os.getenv("image_tag", "")
-          project_path = os.getenv("project_path", "")
-          contract_name = os.getenv("contract_name", "")
-          create_release = os.getenv("create_release", "").lower() == "true"
-          attach_to_existing_release = os.getenv("attach_to_existing_release", "").lower() == "true"
-          skip_preliminary_checks = os.getenv("skip_preliminary_checks", "").lower() == "true"
-          package_whole_project_src = os.getenv("package_whole_project_src", "").lower() == "true"
-
-          logging.info(f"Image tag: {image_tag}")
-          logging.info(f"Project path: {project_path}")
-          logging.info(f"Contract name: {contract_name or '*'}")
-          logging.info(f"Create new release: {create_release}")
-          logging.info(f"Attach output to existing release: {attach_to_existing_release}")
-          logging.info(f"Skip preliminary checks: {skip_preliminary_checks}")
-          logging.info(f"Package whole project src: {package_whole_project_src}")
-
-          if skip_preliminary_checks:
-            logging.warning("You should never set 'skip_preliminary_checks', unless you really know what you are doing!")
-
-          if image_tag == "next":
-            logging.warning("You've chosen to build the contracts with the image 'multiversx/sdk-rust-contract-builder:next', which is experimental and not recommended for production!")
-
-          if contract_name:
-            logging.info(f"One contract will be built: {contract_name}.")
-
-          if create_release and attach_to_existing_release:
-            sys.exit("ERROR: Choose either to create a new release, or to attach the build output to an existing release. Can't pick both. Feel free to pick none, though.")
-          EOF
-        env:
-          image_tag: ${{ inputs.image_tag }}
-          project_path: ${{ inputs.project_path }}
-          contract_name: ${{ inputs.contract_name }}
-          create_release: ${{ inputs.create_release }}
-          attach_to_existing_release: ${{ inputs.attach_to_existing_release }}
-          skip_preliminary_checks: ${{ inputs.skip_preliminary_checks }}
-          package_whole_project_src: ${{ inputs.package_whole_project_src }}
+          if [[ "${{ inputs.create_release }}" == "true" && "${{ inputs.attach_to_existing_release }}" == "true" ]]; then
+            echo "ERROR: Choose either create_release or attach_to_existing_release, not both."
+            exit 1
+          fi
 
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ env.GITHUB_REF_NAME }}
           fetch-depth: 0
-          repository: ${{ env.GITHUB_REPOSITORY }}
 
       - name: Preliminary checks
-        if: ${{ inputs.skip_preliminary_checks == false }}
         run: |
-          python3 - << "EOF"
-          import logging
-          import os
-          import sys
-          from pathlib import Path
+          missing=0
+          while IFS= read -r -d '' cargo_toml; do
+            cargo_lock="${cargo_toml%Cargo.toml}Cargo.lock"
+            if [[ ! -f "$cargo_lock" ]]; then
+              echo "ERROR: wasm/Cargo.lock not found: $cargo_lock"
+              missing=1
+            fi
+          done < <(find "${{ inputs.project_path }}" -path "*/wasm/Cargo.toml" -print0)
+          if [[ $missing -eq 1 ]]; then
+            echo "One or more wasm/Cargo.lock files are missing. They are essential for reproducible builds."
+            exit 1
+          fi
 
-          logging.basicConfig(level=logging.INFO)
+      - name: Install sc-meta
+        run: cargo install multiversx-sc-meta --locked
 
-          project_path = os.getenv("project_path", "")
-          logging.info(f"Project path: {project_path}")
-          logging.info("Check for missing 'wasm/Cargo.lock' files ...")
-
-          missing_cargo_lock = False
-
-          for cargo_toml in Path(project_path).rglob("wasm/Cargo.toml"):
-              cargo_lock = cargo_toml.with_suffix(".lock")
-              if cargo_lock.exists():
-                logging.info(f"Found wasm/Cargo.lock: {cargo_lock}")
-              else:
-                logging.error(f"wasm/Cargo.lock file not found: {cargo_lock}")
-                missing_cargo_lock = True
-            
-          if missing_cargo_lock:
-            sys.exit(f"ERROR: One or more 'wasm/Cargo.lock' files are missing. They are essential for reproducible builds.")
-          EOF
-        env:
-          project_path: ${{ inputs.project_path }}
-
-      - name: Download build script
-        run: |
-          wget https://raw.githubusercontent.com/multiversx/mx-sdk-rust-contract-builder/${{ inputs.image_tag }}/build_with_docker.py
-      
       - name: Build contracts
         run: |
-          flag_package_whole_project_src=""
-          if ${{ inputs.package_whole_project_src }}; then
-            flag_package_whole_project_src="--package-whole-project-src"
+          contract_flag=""
+          if [[ -n "${{ inputs.contract_name }}" ]]; then
+            contract_flag="--contract ${{ inputs.contract_name }}"
           fi
-          
-          python3 ./build_with_docker.py --no-docker-tty --image=multiversx/sdk-rust-contract-builder:${{ inputs.image_tag }} --project=${{ inputs.project_path }} --contract=${{ inputs.contract_name }} --output=/home/runner/work/output-from-docker ${flag_package_whole_project_src}
-      
+
+          sc-meta reproducible-build build \
+            --docker-image "multiversx/sdk-rust-contract-builder:${{ inputs.image_tag }}" \
+            --project "${{ inputs.project_path }}" \
+            --output /home/runner/work/output-from-docker \
+            --no-docker-tty \
+            --no-docker-interactive \
+            $contract_flag
+
       - name: Save artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: build-output
-          path: |
-            /home/runner/work/output-from-docker/**/*.*
+          path: /home/runner/work/output-from-docker/**/*.*
           if-no-files-found: error
 
       - name: Create new release (if applicable)
@@ -146,60 +87,23 @@ jobs:
           sleep 10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          image_tag: ${{ inputs.image_tag }}
 
       - name: Create release notes
         if: ${{ inputs.attach_to_existing_release == true || inputs.create_release == true }}
         run: |
-          python3 - << "EOF"
-          import logging
-          from hashlib import blake2b
-          from pathlib import Path
-          import os
-          import json
-          import urllib.request
-
-          logging.basicConfig(level=logging.INFO)
-
-          repository = os.getenv("GITHUB_REPOSITORY")
-          ref_name = os.getenv("GITHUB_REF_NAME")
-          image_tag = os.getenv("image_tag", "")
-
-          try:
-            logging.info(f"Fetching existing release notes, if any, for repository = {repository}, tag = {ref_name} ...")
-            
-            request = urllib.request.urlopen(f"https://api.github.com/repos/{repository}/releases/tags/{ref_name}")
-            data = json.loads(request.read())
-            existing_notes = data["body"]
-          except Exception as err:
-            logging.info("An error ocurred while fetching existing release notes (perhaps there is no release yet).")
-            existing_notes = ""
-
-          notes = existing_notes + "\n\n"
-          notes += "Built using Docker image: **multiversx/sdk-rust-contract-builder:${{ inputs.image_tag }}**.\n"
-          notes += "\n"
-          notes+= "## Codehashes (blake2b):\n"
-
-          for wasm_file in Path("/home/runner/work/output-from-docker").rglob("*.wasm"):
-            code = wasm_file.read_bytes()
-            h = blake2b(digest_size=32)
-            h.update(code)
-            notes += f"**{wasm_file.name}**: `{h.hexdigest()}`\n"
-
-          Path("release_notes.txt").write_text(notes)
-          EOF
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          image_tag: ${{ inputs.image_tag }}
+          sc-meta reproducible-build release-notes \
+            --artifacts /home/runner/work/output-from-docker/artifacts.json \
+            --docker-image "multiversx/sdk-rust-contract-builder:${{ inputs.image_tag }}" \
+            --output release_notes.txt
 
       - name: Upload artifacts to release, edit release notes
         if: ${{ inputs.attach_to_existing_release == true || inputs.create_release == true }}
         run: |
           gh release edit ${{ github.ref_name }} --notes-file=release_notes.txt
 
-          gh release upload ${{ github.ref_name }} $(find /home/runner/work/output-from-docker/**/*.wasm -type f)
-          gh release upload ${{ github.ref_name }} $(find /home/runner/work/output-from-docker/**/*.source.json -type f)
-          gh release upload ${{ github.ref_name }} $(find /home/runner/work/output-from-docker/**/*.abi.json -type f)
-          gh release upload ${{ github.ref_name }} $(find /home/runner/work/output-from-docker/artifacts.json -type f)
+          gh release upload ${{ github.ref_name }} $(find /home/runner/work/output-from-docker -name "*.wasm" -type f)
+          gh release upload ${{ github.ref_name }} $(find /home/runner/work/output-from-docker -name "*.source.json" -type f)
+          gh release upload ${{ github.ref_name }} $(find /home/runner/work/output-from-docker -name "*.abi.json" -type f)
+          gh release upload ${{ github.ref_name }} $(find /home/runner/work/output-from-docker -name "artifacts.json" -type f)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -39,21 +39,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Preliminary checks
-        run: |
-          missing=0
-          while IFS= read -r -d '' cargo_toml; do
-            cargo_lock="${cargo_toml%Cargo.toml}Cargo.lock"
-            if [[ ! -f "$cargo_lock" ]]; then
-              echo "ERROR: wasm/Cargo.lock not found: $cargo_lock"
-              missing=1
-            fi
-          done < <(find "${{ inputs.project_path }}" -path "*/wasm/Cargo.toml" -print0)
-          if [[ $missing -eq 1 ]]; then
-            echo "One or more wasm/Cargo.lock files are missing. They are essential for reproducible builds."
-            exit 1
-          fi
-
       - name: Install sc-meta
         run: cargo install multiversx-sc-meta --locked
 

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -59,9 +59,9 @@ jobs:
 
       - name: Build contracts
         run: |
-          contract_flag=""
+          args=()
           if [[ -n "${{ inputs.contract_name }}" ]]; then
-            contract_flag="--contract ${{ inputs.contract_name }}"
+            args+=(--contract "${{ inputs.contract_name }}")
           fi
 
           sc-meta reproducible-build build \
@@ -70,7 +70,7 @@ jobs:
             --output /home/runner/work/output-from-docker \
             --no-docker-tty \
             --no-docker-interactive \
-            $contract_flag
+            "${args[@]}"
 
       - name: Save artifacts
         uses: actions/upload-artifact@v4
@@ -82,7 +82,7 @@ jobs:
       - name: Create new release (if applicable)
         if: ${{ inputs.create_release == true }}
         run: |
-          gh release create ${{ github.ref_name }} --target=$GITHUB_SHA --prerelease --title="New release: ${{ github.ref_name }}" --generate-notes
+          gh release create "${{ github.ref_name }}" --target="$GITHUB_SHA" --prerelease --title="New release: ${{ github.ref_name }}" --generate-notes
           # Give some time for processing the request
           sleep 10
         env:
@@ -99,11 +99,11 @@ jobs:
       - name: Upload artifacts to release, edit release notes
         if: ${{ inputs.attach_to_existing_release == true || inputs.create_release == true }}
         run: |
-          gh release edit ${{ github.ref_name }} --notes-file=release_notes.txt
+          gh release edit "${{ github.ref_name }}" --notes-file=release_notes.txt
 
-          gh release upload ${{ github.ref_name }} $(find /home/runner/work/output-from-docker -name "*.wasm" -type f)
-          gh release upload ${{ github.ref_name }} $(find /home/runner/work/output-from-docker -name "*.source.json" -type f)
-          gh release upload ${{ github.ref_name }} $(find /home/runner/work/output-from-docker -name "*.abi.json" -type f)
-          gh release upload ${{ github.ref_name }} $(find /home/runner/work/output-from-docker -name "artifacts.json" -type f)
+          gh release upload "${{ github.ref_name }}" $(find /home/runner/work/output-from-docker -name "*.wasm" -type f)
+          gh release upload "${{ github.ref_name }}" $(find /home/runner/work/output-from-docker -name "*.source.json" -type f)
+          gh release upload "${{ github.ref_name }}" $(find /home/runner/work/output-from-docker -name "*.abi.json" -type f)
+          gh release upload "${{ github.ref_name }}" $(find /home/runner/work/output-from-docker -name "artifacts.json" -type f)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -13,7 +13,7 @@ on:
         type: string
       rust-target:
         description: "Rust target to use"
-        default: "wasm32-unknown-unknown"
+        default: "wasm32v1-none"
         required: false
         type: string
       sc-meta-version:

--- a/README.md
+++ b/README.md
@@ -334,6 +334,12 @@ This modular approach allows you to:
 
 See [reproducible-build.yml](.github/workflows/reproducible-build.yml).
 
+The workflow builds contracts deterministically inside a pinned Docker image (`multiversx/sdk-rust-contract-builder`) using `sc-meta reproducible-build build`. It installs `sc-meta` on the runner, which orchestrates the Docker container, runs the build with `--locked` (so Cargo refuses to update or create any `Cargo.lock` file), verifies that no `Cargo.lock` files were created or modified during the build, and produces an `artifacts.json` summary alongside the compiled `.wasm`, `.abi.json`, and `.source.json` files.
+
+Release notes (with blake2b codehashes) are generated via `sc-meta reproducible-build release-notes`.
+
+> **Prerequisite:** every `wasm/` crate must have a committed `Cargo.lock`. The build will fail if any are missing, because `--locked` requires the lock file to already exist.
+
 ## Configuration entries
 
 The following configuration entries are available:
@@ -343,8 +349,6 @@ The following configuration entries are available:
 - `contract_name`: a specific contract to be built. If not specified, all contracts in the workspace (repository) are built.
 - `create_release`: whether to create a new release (and upload the build artifacts as assets).
 - `attach_to_existing_release`: whether to upload the build artifacts on an existing release. This only works if the current `github.ref_name` (of the executing workflow) is associated with an existing release.
-- `skip_preliminary_checks`: whether to skip the preliminary checks. **Never set this in production!**
-- `package_whole_project_src`: whether to include all project files in the packaged source (`*.source.json`).
 
 Note that `create_release` and `attach_to_existing_release` are mutually exclusive.
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ jobs:
     with:
       rust-toolchain: "stable"  # optional, default: "stable"
       runs-on: "ubuntu-latest"  # optional, default: "ubuntu-latest"
-      rust-target: "wasm32-unknown-unknown"  # optional, default: "wasm32-unknown-unknown"
+      rust-target: "wasm32v1-none"  # optional, default: "wasm32v1-none"
       sc-meta-version: ""  # optional, default: latest
       mx-scenario-go-version: ""  # optional, default: latest
       wasm-opt-version: "108"  # optional, default: "108"
@@ -128,7 +128,7 @@ jobs:
     with:
       rust-toolchain: "stable"  # optional, default: "stable"
       runs-on: "ubuntu-latest"  # optional, default: "ubuntu-latest"
-      rust-target: "wasm32-unknown-unknown"  # optional, default: "wasm32-unknown-unknown"
+      rust-target: "wasm32v1-none"  # optional, default: "wasm32v1-none"
 ```
 
 #### 3. Wasm Tests (`wasm-tests.yml`)
@@ -171,7 +171,7 @@ jobs:
     with:
       rust-toolchain: "stable"  # optional, default: "stable"
       runs-on: "ubuntu-latest"  # optional, default: "ubuntu-latest"
-      rust-target: "wasm32-unknown-unknown"  # optional, default: "wasm32-unknown-unknown"
+      rust-target: "wasm32v1-none"  # optional, default: "wasm32v1-none"
       coverage-args: "--output ./coverage.md"  # optional, default: "--output ./coverage.md"
 ```
 


### PR DESCRIPTION
## Pull request overview

This PR updates the reusable GitHub Actions workflows to support deterministic/reproducible smart contract builds via `sc-meta reproducible-build`, and switches the default Rust WASM compilation target to `wasm32v1-none`.

**Changes:**
- Switched default `rust-target` across reusable workflows and README examples from `wasm32-unknown-unknown` to `wasm32v1-none`.
- Refactored `reproducible-build.yml` to use `sc-meta reproducible-build build` / `release-notes` instead of a downloaded Python build script and custom release-notes logic.
- Updated README documentation for the reproducible-build workflow and removed no-longer-supported inputs.
